### PR TITLE
custom execution environment for capabilities

### DIFF
--- a/common/common.awx/common.awx.client/src/main/java/org/eclipse/slm/common/awx/client/AwxClient.java
+++ b/common/common.awx/common.awx.client/src/main/java/org/eclipse/slm/common/awx/client/AwxClient.java
@@ -923,29 +923,25 @@ public class AwxClient {
         return Optional.empty();
     }
 
-    public Optional<ExecutionEnvironment> createOrUpdateExecutionEnvironment(ExecutionEnvironmentCreate executionEnvironmentCreate){
+    public Optional<ExecutionEnvironment> createOrUpdateExecutionEnvironment(ExecutionEnvironmentCreate executionEnvironmentCreate) {
         String url = this.getAwxApiUrl() + "/execution_environments/";
         HttpHeaders headers = getAdminAuthHeader();
 
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<ExecutionEnvironmentCreate> httpEntity = new HttpEntity<>(executionEnvironmentCreate, headers);
 
-        try{
+        var ee = this.getExecutionEnvironmentByName(executionEnvironmentCreate.getName());
+        if (ee.isEmpty()) {
             restTemplate.postForEntity(url, httpEntity, ExecutionEnvironment.class);
 
             return this.getExecutionEnvironmentByName(executionEnvironmentCreate.getName());
-        }catch (HttpClientErrorException e){
-            log.info("ExecutionEnvironment exists already => update ExecutionEnvironment");
-            var ee = this.getExecutionEnvironmentByName(executionEnvironmentCreate.getName());
-            if (ee.isEmpty()){
-                return Optional.empty();
-            }
-
-            url += ee.get().getId();
-            restTemplate.put(url, httpEntity);
-
-            return this.getExecutionEnvironmentByName(executionEnvironmentCreate.getName());
         }
+
+        log.info("ExecutionEnvironment exists already => update ExecutionEnvironment");
+        url += ee.get().getId();
+        restTemplate.put(url, httpEntity);
+
+        return this.getExecutionEnvironmentByName(executionEnvironmentCreate.getName());
 
     }
 

--- a/common/common.awx/common.awx.client/src/main/java/org/eclipse/slm/common/awx/client/AwxClient.java
+++ b/common/common.awx/common.awx.client/src/main/java/org/eclipse/slm/common/awx/client/AwxClient.java
@@ -938,8 +938,8 @@ public class AwxClient {
         }
 
         log.info("ExecutionEnvironment exists already => update ExecutionEnvironment");
-        url += ee.get().getId();
-        restTemplate.put(url, httpEntity);
+        url += ee.get().getId() + "/";
+        restTemplate.exchange(url, HttpMethod.PUT, httpEntity, Void.class);
 
         return this.getExecutionEnvironmentByName(executionEnvironmentCreate.getName());
 

--- a/common/common.awx/common.awx.client/src/main/java/org/eclipse/slm/common/awx/client/AwxClient.java
+++ b/common/common.awx/common.awx.client/src/main/java/org/eclipse/slm/common/awx/client/AwxClient.java
@@ -2,11 +2,7 @@ package org.eclipse.slm.common.awx.client;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeCreator;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.util.JSONPObject;
 import com.fasterxml.jackson.module.kotlin.KotlinModule;
 import org.eclipse.slm.common.awx.model.*;
 import org.eclipse.slm.notification_service.model.JobFinalState;
@@ -916,12 +912,41 @@ public class AwxClient {
                 new HttpEntity<>(null, getAdminAuthHeader()),
                 new ParameterizedTypeReference<Results<ExecutionEnvironment>>() {});
         Results<ExecutionEnvironment> executionEnvironmentResults = response.getBody();
-        if(executionEnvironmentResults.getCount() == 1){
-
-            return executionEnvironmentResults.getResults().stream().findFirst();
+        if(executionEnvironmentResults.getCount() > 0){
+            for (ExecutionEnvironment executionEnvironment : executionEnvironmentResults.getResults()) {
+                if (name.equals(executionEnvironment.getName())) {
+                    return Optional.of(executionEnvironment);
+                }
+            }
         }
 
         return Optional.empty();
+    }
+
+    public Optional<ExecutionEnvironment> createOrUpdateExecutionEnvironment(ExecutionEnvironmentCreate executionEnvironmentCreate){
+        String url = this.getAwxApiUrl() + "/execution_environments/";
+        HttpHeaders headers = getAdminAuthHeader();
+
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<ExecutionEnvironmentCreate> httpEntity = new HttpEntity<>(executionEnvironmentCreate, headers);
+
+        try{
+            restTemplate.postForEntity(url, httpEntity, ExecutionEnvironment.class);
+
+            return this.getExecutionEnvironmentByName(executionEnvironmentCreate.getName());
+        }catch (HttpClientErrorException e){
+            log.info("ExecutionEnvironment exists already => update ExecutionEnvironment");
+            var ee = this.getExecutionEnvironmentByName(executionEnvironmentCreate.getName());
+            if (ee.isEmpty()){
+                return Optional.empty();
+            }
+
+            url += ee.get().getId();
+            restTemplate.put(url, httpEntity);
+
+            return this.getExecutionEnvironmentByName(executionEnvironmentCreate.getName());
+        }
+
     }
 
     public JobTemplate createJobTemplateAndAddExecuteRoleToDefaultTeam(

--- a/common/common.awx/common.awx.model/src/main/java/org/eclipse/slm/common/awx/model/CredentialDTOApiCreate.kt
+++ b/common/common.awx/common.awx.model/src/main/java/org/eclipse/slm/common/awx/model/CredentialDTOApiCreate.kt
@@ -5,5 +5,5 @@ data class CredentialDTOApiCreate(
     val description: String,
     val organization: Int?,
     val credential_type: Int,
-    val inputs: Map<String, String>
+    val inputs: Map<String, Object>
 )

--- a/common/common.awx/common.awx.model/src/main/java/org/eclipse/slm/common/awx/model/CredentialDTOApiUpdate.kt
+++ b/common/common.awx/common.awx.model/src/main/java/org/eclipse/slm/common/awx/model/CredentialDTOApiUpdate.kt
@@ -5,5 +5,5 @@ data class CredentialDTOApiUpdate(
     val description: String?,
     val organization: Int?,
     val credential_type: Int,
-    val inputs: Map<String, String>
+    val inputs: Map<String, Object>
 )

--- a/common/common.awx/common.awx.model/src/main/java/org/eclipse/slm/common/awx/model/ExecutionEnvironmentCreate.kt
+++ b/common/common.awx/common.awx.model/src/main/java/org/eclipse/slm/common/awx/model/ExecutionEnvironmentCreate.kt
@@ -1,0 +1,14 @@
+package org.eclipse.slm.common.awx.model
+
+class ExecutionEnvironmentCreate (
+
+    var name: String,
+    var description: String,
+    val organization: Int,
+    var image: String,
+    var managed: String,
+    val credential: Int?,
+    var pull: String
+
+) {
+}

--- a/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/capabilities/Capability.kt
+++ b/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/capabilities/Capability.kt
@@ -67,7 +67,7 @@ abstract class Capability(id: UUID? = null) {
     @Column(name = "connection")
     open var connection: ConnectionType? = null
 
-    @Column(name = "execution_environment")
+    @Column(name = "execution_environment", columnDefinition = "LONGTEXT")
     @Type(type = "json")
     open var executionEnvironment: ExecutionEnvironment? = null
 

--- a/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/capabilities/Capability.kt
+++ b/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/capabilities/Capability.kt
@@ -9,6 +9,7 @@ import org.eclipse.slm.resource_management.model.actions.Action
 import org.eclipse.slm.resource_management.model.actions.ActionType
 import org.eclipse.slm.resource_management.model.cluster.ClusterMemberType
 import org.eclipse.slm.resource_management.model.resource.ConnectionType
+import org.eclipse.slm.resource_management.model.resource.ExecutionEnvironment
 import org.hibernate.annotations.Type
 import org.hibernate.annotations.TypeDef
 import org.hibernate.annotations.TypeDefs
@@ -65,6 +66,10 @@ abstract class Capability(id: UUID? = null) {
 
     @Column(name = "connection")
     open var connection: ConnectionType? = null
+
+    @Column(name = "execution_environment")
+    @Type(type = "json")
+    open var executionEnvironment: ExecutionEnvironment? = null
 
     fun isCluster(): Boolean {
         return clusterMemberTypes.isNotEmpty();

--- a/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/capabilities/CapabilityDTOApi.kt
+++ b/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/capabilities/CapabilityDTOApi.kt
@@ -8,6 +8,7 @@ import org.eclipse.slm.resource_management.model.actions.Action
 import org.eclipse.slm.resource_management.model.actions.ActionType
 import org.eclipse.slm.resource_management.model.cluster.ClusterMemberType
 import org.eclipse.slm.resource_management.model.resource.ConnectionType
+import org.eclipse.slm.resource_management.model.resource.ExecutionEnvironment
 import java.util.*
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "capabilityClass")
@@ -37,6 +38,8 @@ abstract class CapabilityDTOApi(id: UUID? = null, capabilityClass: String) {
     open var clusterMemberTypes: List<ClusterMemberType> = ArrayList()
 
     open var connection: ConnectionType? = null
+
+    open var executionEnvironment: ExecutionEnvironment? = null
 
     override fun toString(): String {
         return "CapabilityDTOApi(id=$id, name='$name', logo='$logo', type=$type, actions=$actions)"

--- a/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/ExecutionEnvironment.kt
+++ b/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/ExecutionEnvironment.kt
@@ -1,0 +1,9 @@
+package org.eclipse.slm.resource_management.model.resource
+
+
+class ExecutionEnvironment {
+    var image: String = ""
+    var pull: ExecutionEnvironmentPull = ExecutionEnvironmentPull.None
+    var description: String = ""
+    var registryCredential: RegistryCredentials? = null
+}

--- a/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/ExecutionEnvironmentPull.kt
+++ b/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/ExecutionEnvironmentPull.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue
 
 enum class ExecutionEnvironmentPull(@JsonValue val prettyName: String = "") {
     None(""),
-    Always("allways"),
+    Always("always"),
     Missing("missing"),
     Never("never")
 }

--- a/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/ExecutionEnvironmentPull.kt
+++ b/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/ExecutionEnvironmentPull.kt
@@ -1,0 +1,11 @@
+package org.eclipse.slm.resource_management.model.resource
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+
+enum class ExecutionEnvironmentPull(@JsonValue val prettyName: String = "") {
+    None(""),
+    Always("allways"),
+    Missing("missing"),
+    Never("never")
+}

--- a/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/RegistryCredentials.kt
+++ b/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/RegistryCredentials.kt
@@ -1,6 +1,7 @@
 package org.eclipse.slm.resource_management.model.resource
 
 class RegistryCredentials {
+    var id: Int? = null
     var description: String? = null
     var authenticationURL: String = "quary.io"
     var username: String = ""

--- a/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/RegistryCredentials.kt
+++ b/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/RegistryCredentials.kt
@@ -1,0 +1,9 @@
+package org.eclipse.slm.resource_management.model.resource
+
+class RegistryCredentials {
+    var description: String? = null
+    var authenticationURL: String = "quary.io"
+    var username: String = ""
+    var password: String = ""
+    var verifySSL: Boolean = true
+}

--- a/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/exceptions/ResourceInternalErrorException.java
+++ b/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/exceptions/ResourceInternalErrorException.java
@@ -1,0 +1,13 @@
+package org.eclipse.slm.resource_management.model.resource.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+public class ResourceInternalErrorException extends Exception {
+
+    public ResourceInternalErrorException(String reason){
+        super("Resource could not created because of " + reason);
+    }
+
+}

--- a/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/exceptions/ResourceNotCreatedException.java
+++ b/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/exceptions/ResourceNotCreatedException.java
@@ -1,0 +1,13 @@
+package org.eclipse.slm.resource_management.model.resource.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+public class ResourceNotCreatedException extends Exception {
+
+    public ResourceNotCreatedException(String reason){
+        super("Resource could not created because of " + reason);
+    }
+
+}

--- a/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/exceptions/ResourceNotFoundException.java
+++ b/resource_management/resource_management.model/src/main/java/org/eclipse/slm/resource_management/model/resource/exceptions/ResourceNotFoundException.java
@@ -13,4 +13,8 @@ public class ResourceNotFoundException extends Exception {
         super("Resource with id '"  + resourceId + "' not found");
     }
 
+    public ResourceNotFoundException(String name){
+        super("Resource with name '" + name + "' not found");
+    }
+
 }

--- a/resource_management/resource_management.service/resource_management.service.initializer/src/main/resources/init-dev/capabilities.json
+++ b/resource_management/resource_management.service/resource_management.service.initializer/src/main/resources/init-dev/capabilities.json
@@ -49,7 +49,18 @@
       "DOCKER_CONTAINER",
       "DOCKER_COMPOSE"
     ],
-    "clusterMemberTypes": []
+    "clusterMemberTypes": [],
+    "executionEnvironment": {
+      "image": "ghcr.io/eclipse-slm/awx-ee-slm:1.4.0-snapshot",
+      "pull": "",
+      "description": "TEST TEST TEST",
+      "registryCredential": {
+        "description": "TEST TEST TEST",
+        "authenticationURL": "quary.io",
+        "username": "username-test",
+        "password": "password-test"
+      }
+    }
   },
   {
     "id": "b5cc76b3-c3cf-4df2-94ec-622245de34d1",

--- a/resource_management/resource_management.service/resource_management.service.rest/src/main/java/org/eclipse/slm/resource_management/service/rest/capabilities/CapabilitiesManager.java
+++ b/resource_management/resource_management.service/resource_management.service.rest/src/main/java/org/eclipse/slm/resource_management/service/rest/capabilities/CapabilitiesManager.java
@@ -198,6 +198,9 @@ public class CapabilitiesManager implements IAwxJobObserverListener {
             throws ResourceNotCreatedException, JsonProcessingException, ResourceInternalErrorException {
         if (capability.getExecutionEnvironment() != null) {
 
+            var executionName = capability.getName() + "-EE";
+            LOG.info("Create or Update Execution Environment with name " + executionName);
+
             var executionEnvironment = capability.getExecutionEnvironment();
 
             var organisationName = "Service Lifecycle Management";
@@ -218,7 +221,7 @@ public class CapabilitiesManager implements IAwxJobObserverListener {
             Credential credential = createRegistryCredential(capability, executionEnvironment, organization);
 
             var ee = this.awxClient.createOrUpdateExecutionEnvironment(new ExecutionEnvironmentCreate(
-                    capability.getName() + "-EE",
+                    executionName,
                     executionEnvironment.getDescription(),
                     organization.getId(),
                     executionEnvironment.getImage(),
@@ -228,7 +231,7 @@ public class CapabilitiesManager implements IAwxJobObserverListener {
             ));
 
             if (ee.isEmpty()) {
-                throw new ResourceNotCreatedException("Could not create Execution Environment for capability" + capability.getName());
+                throw new ResourceNotCreatedException("Could not create Execution Environment for capability" + executionName);
             }
         }
     }

--- a/resource_management/resource_management.service/resource_management.service.rest/src/main/java/org/eclipse/slm/resource_management/service/rest/capabilities/CapabilitiesManager.java
+++ b/resource_management/resource_management.service/resource_management.service.rest/src/main/java/org/eclipse/slm/resource_management/service/rest/capabilities/CapabilitiesManager.java
@@ -238,20 +238,30 @@ public class CapabilitiesManager implements IAwxJobObserverListener {
         var newCredentials = executionEnvironment.getRegistryCredential();
         Credential credential = null;
         if (newCredentials != null) {
-            credential = this.awxClient.createCredential(new CredentialDTOApiCreate(
-                    capability.getName() + "-rc",
-                    Objects.requireNonNullElse(newCredentials.getDescription(), ""),
-                    organization.getId(),
-                    17,
-                    new HashMap<String, Object>() {{
-                        put("host", newCredentials.getAuthenticationURL());
-                        put("username", newCredentials.getUsername());
-                        put("password", newCredentials.getPassword());
-                        put("verify_ssl", newCredentials.getVerifySSL());
-                    }}
-            ));
-            if (credential == null) {
-                throw new ResourceNotCreatedException("Could not create Credential for Execution-Environment for capability: " + capability.getName());
+
+            if (newCredentials.getId() != null){
+                credential = this.awxClient.getCredentialById(newCredentials.getId());
+
+                if (credential == null) {
+                    throw new ResourceNotCreatedException("Could not find Credential with Id "+newCredentials.getId()+" for Execution-Environment for capability: " + capability.getName());
+                }
+            }else{
+                credential = this.awxClient.createCredential(new CredentialDTOApiCreate(
+                        capability.getName() + "-rc",
+                        Objects.requireNonNullElse(newCredentials.getDescription(), ""),
+                        organization.getId(),
+                        17,
+                        new HashMap<String, Object>() {{
+                            put("host", newCredentials.getAuthenticationURL());
+                            put("username", newCredentials.getUsername());
+                            put("password", newCredentials.getPassword());
+                            put("verify_ssl", newCredentials.getVerifySSL());
+                        }}
+                ));
+
+                if (credential == null) {
+                    throw new ResourceNotCreatedException("Could not create Credential for Execution-Environment for capability: " + capability.getName());
+                }
             }
         }
         return credential;

--- a/resource_management/resource_management.service/resource_management.service.rest/src/main/java/org/eclipse/slm/resource_management/service/rest/capabilities/CapabilitiesManager.java
+++ b/resource_management/resource_management.service/resource_management.service.rest/src/main/java/org/eclipse/slm/resource_management/service/rest/capabilities/CapabilitiesManager.java
@@ -247,7 +247,7 @@ public class CapabilitiesManager implements IAwxJobObserverListener {
                 }
             }else{
                 credential = this.awxClient.createCredential(new CredentialDTOApiCreate(
-                        capability.getName() + "-rc",
+                        capability.getName() + "-Credential",
                         Objects.requireNonNullElse(newCredentials.getDescription(), ""),
                         organization.getId(),
                         17,

--- a/resource_management/resource_management.service/resource_management.service.rest/src/main/java/org/eclipse/slm/resource_management/service/rest/capabilities/CapabilitiesRestController.java
+++ b/resource_management/resource_management.service/resource_management.service.rest/src/main/java/org/eclipse/slm/resource_management/service/rest/capabilities/CapabilitiesRestController.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.eclipse.slm.common.consul.client.ConsulCredential;
 import org.eclipse.slm.common.consul.model.exceptions.ConsulLoginFailedException;
 import org.eclipse.slm.resource_management.model.capabilities.*;
+import org.eclipse.slm.resource_management.model.resource.exceptions.ResourceInternalErrorException;
+import org.eclipse.slm.resource_management.model.resource.exceptions.ResourceNotCreatedException;
 import org.eclipse.slm.resource_management.service.rest.resources.ResourcesManager;
 import org.eclipse.slm.resource_management.model.consul.capability.CapabilityService;
 import org.eclipse.slm.resource_management.model.resource.exceptions.ResourceNotFoundException;
@@ -82,7 +84,7 @@ public class CapabilitiesRestController {
     @Operation(summary = "Add capability")
     public ResponseEntity<Void> createCapability(
             @RequestBody CapabilityDTOApi capabilityDTOApi
-    ) throws ConsulLoginFailedException, ResourceNotFoundException, IllegalAccessException {
+    ) throws ConsulLoginFailedException, ResourceNotFoundException, IllegalAccessException, ResourceNotCreatedException, JsonProcessingException, ResourceInternalErrorException {
         Capability capability = modelMapper.map(capabilityDTOApi, Capability.class);
         capabilitiesManager.addCapability(capability);
         LOG.info("Added capability: " + capabilityDTOApi.toString());

--- a/resource_management/resource_management.service/resource_management.service.rest/src/test/java/org/eclipse/slm/resource_management/service/rest/capabilities/CapabilitiesManagerTest.java
+++ b/resource_management/resource_management.service/resource_management.service.rest/src/test/java/org/eclipse/slm/resource_management/service/rest/capabilities/CapabilitiesManagerTest.java
@@ -23,6 +23,8 @@ import org.eclipse.slm.resource_management.model.capabilities.*;
 import org.eclipse.slm.resource_management.model.actions.AwxAction;
 import org.eclipse.slm.resource_management.model.actions.ActionType;
 import org.eclipse.slm.resource_management.model.consul.capability.SingleHostCapabilityService;
+import org.eclipse.slm.resource_management.model.resource.exceptions.ResourceInternalErrorException;
+import org.eclipse.slm.resource_management.model.resource.exceptions.ResourceNotCreatedException;
 import org.eclipse.slm.resource_management.model.resource.exceptions.ResourceNotFoundException;
 import org.eclipse.slm.resource_management.persistence.api.CapabilityJpaRepository;
 import org.junit.jupiter.api.*;
@@ -143,7 +145,7 @@ public class CapabilitiesManagerTest {
 
         @Test
         @Order(20)
-        public void testAddDeploymentCapability() throws ConsulLoginFailedException, ResourceNotFoundException, IllegalAccessException {
+        public void testAddDeploymentCapability() throws ConsulLoginFailedException, ResourceNotFoundException, IllegalAccessException, ResourceNotCreatedException, JsonProcessingException, ResourceInternalErrorException {
             capabilitiesManager.addCapability(dockerDeploymentCapability);
         }
 
@@ -413,7 +415,7 @@ public class CapabilitiesManagerTest {
 
         @Test
         @Order(20)
-        public void testAddVirtualizationCapability() throws ConsulLoginFailedException, ResourceNotFoundException, IllegalAccessException {
+        public void testAddVirtualizationCapability() throws ConsulLoginFailedException, ResourceNotFoundException, IllegalAccessException, ResourceNotCreatedException, JsonProcessingException, ResourceInternalErrorException {
             capabilitiesManager.addCapability(virtualizationCapability);
         }
 
@@ -494,7 +496,7 @@ public class CapabilitiesManagerTest {
 
         @Test
         @Order(75)
-        public void testAddCapabilityWithParams() throws ConsulLoginFailedException, ResourceNotFoundException, AwxProjectUpdateFailedException, JsonProcessingException, SSLException, IllegalAccessException {
+        public void testAddCapabilityWithParams() throws ConsulLoginFailedException, ResourceNotFoundException, AwxProjectUpdateFailedException, JsonProcessingException, SSLException, IllegalAccessException, ResourceNotCreatedException, ResourceInternalErrorException {
             AwxAction action = (AwxAction) virtualizationCapability.getActions().get(ActionType.CREATE_VM);
             action.setParameter(surveyItems);
 


### PR DESCRIPTION
Add a new property for the capability to create an execution environment with an optional registry credential. 
For example with a given credential 
```json
"executionEnvironment": {
      "image": "ghcr.io/eclipse-slm/awx-ee-slm:1.4.0-snapshot",
      "pull": "",
      "description": "EE for XY",
      "registryCredential": {
        "id": 9,
      }
    }
```
or a new credential
```json
"executionEnvironment": {
      "image": "ghcr.io/eclipse-slm/awx-ee-slm:1.4.0-snapshot",
      "pull": "", 
      "description": "EE for XY",
      "registryCredential": {
        "description": "Credential for XY",
        "authenticationURL": "quary.io",
        "username": "username-test",
        "password": "password-test"
      }
    }
```
 Possible values for "pull": "", "always", "missing", "never"

The name of the Execution Environment and the Credential will be created out of the name of the capability. 
Execution Environment: "{{capability name}}-EE"
Credential: "{{capability name}}-Credential"
    
   